### PR TITLE
continue in switch needs continue 2

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -1343,7 +1343,7 @@ function mod_qcreate_get_completion_active_rule_descriptions($cm) {
         switch ($key) {
             case 'completionquestions':
                 if (empty($val)) {
-                    continue;
+                    continue 2;
                 }
                 $descriptions[] = get_string('completionquestionsdesc', 'qcreate', $val);
                 break;


### PR DESCRIPTION
`Warning:  "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in /data/web/www/vhosts/www.eduvidual.at/mod/qcreate/lib.php on line 1346`

--> a continue regarding the foreach statement within a switch needs to be stated as "continue 2", otherwise it acts as a break.

https://www.php.net/manual/en/control-structures.continue.php