### PR TITLE
fix phpunit test

### DIFF
--- a/tests/base_test.php
+++ b/tests/base_test.php
@@ -84,7 +84,7 @@ class mod_qcreate_base_testcase extends advanced_testcase {
     /**
      * Setup function - we will create a course and add a qcreate instance to it.
      */
-    protected function setUp() {
+    protected function setUp() :void {
         global $DB;
 
         $this->resetAfterTest(true);

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -39,7 +39,7 @@ require_once($CFG->dirroot . '/mod/qcreate/tests/base_test.php');
  */
 class mod_qcreate_lib_testcase extends mod_qcreate_base_testcase {
 
-    protected function setUp() {
+    protected function setUp() :void {
         parent::setUp();
 
         // Add additional default data.


### PR DESCRIPTION
```
Fatal error: Declaration of mod_qcreate_base_testcase::setUp() must be compatible with PHPUnit\Framework\TestCase::setUp(): void in /home/runner/work/xxxx/eduvidual-src/mod/qcreate/tests/base_test.php on line 213
```